### PR TITLE
LSC: single-tag-per-route caching + customer-group cache vary

### DIFF
--- a/packages/Webkul/LSC/src/Http/Controllers/API/CartCountController.php
+++ b/packages/Webkul/LSC/src/Http/Controllers/API/CartCountController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Webkul\LSC\Http\Controllers\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Webkul\Checkout\Facades\Cart;
+use Webkul\LSC\Support\PrivateEsiCache;
+use Webkul\Shop\Http\Controllers\API\APIController;
+
+class CartCountController extends APIController
+{
+    /**
+     * Render the mini-cart count badge as a raw-HTML ESI fragment.
+     *
+     * This seeds the cart badge server-side for an instant first paint (no
+     * shimmer flash). The `v-mini-cart` Vue component still mounts over the
+     * placeholder and takes over live, in-page updates (add/remove without a
+     * reload), so this fragment only needs to be correct on full navigation —
+     * which the cart-count purge on cart mutations guarantees.
+     */
+    public function index(Request $request): Response
+    {
+        $cart = Cart::getCart();
+
+        $html = view('lsc::shop.home.cart-count', [
+            'itemsQty'   => (int) ($cart?->items_qty ?? 0),
+            'itemsCount' => (int) ($cart?->items_count ?? 0),
+        ])->render();
+
+        $response = response($html, Response::HTTP_OK)
+            ->header('Content-Type', 'text/html; charset=UTF-8');
+
+        return PrivateEsiCache::apply($response, $request, 'cart-count');
+    }
+}

--- a/packages/Webkul/LSC/src/Http/Controllers/API/LoginContentController.php
+++ b/packages/Webkul/LSC/src/Http/Controllers/API/LoginContentController.php
@@ -3,13 +3,24 @@
 namespace Webkul\LSC\Http\Controllers\API;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Webkul\LSC\Support\PrivateEsiCache;
 use Webkul\Shop\Http\Controllers\API\APIController;
 
 class LoginContentController extends APIController
 {
     /**
+     * Private-cache scope shared by the three login fragments. A single scope
+     * means one purge (on login/logout) invalidates all of them for a context.
+     */
+    private const ESI_SCOPE = 'login';
+
+    /**
      * Render login content view and return as JSON.
+     *
+     * Used by the AJAX/Vue fallback path (OpenLiteSpeed / local dev), which
+     * injects `data` via innerHTML.
      */
     private function renderLoginContent(string $viewName): JsonResponse
     {
@@ -25,6 +36,47 @@ class LoginContentController extends APIController
                 'message' => $e->getMessage(),
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * Render a login fragment as raw HTML for an ESI include.
+     *
+     * LiteSpeed injects the response body verbatim into the cached page, so
+     * this returns HTML (not the JSON wrapper) and carries private-cache
+     * headers so the fragment is cached per-user at the edge.
+     */
+    private function renderEsiFragment(Request $request, string $viewName): Response
+    {
+        $html = view($viewName)->render();
+
+        $response = response($html, Response::HTTP_OK)
+            ->header('Content-Type', 'text/html; charset=UTF-8');
+
+        return PrivateEsiCache::apply($response, $request, self::ESI_SCOPE);
+    }
+
+    /**
+     * ESI: login dropdown content for desktop.
+     */
+    public function esiLoginDesktopDropdown(Request $request): Response
+    {
+        return $this->renderEsiFragment($request, 'lsc::shop.home.login-desktop-dropdown');
+    }
+
+    /**
+     * ESI: login dropdown content for mobile.
+     */
+    public function esiLoginMobileDropdown(Request $request): Response
+    {
+        return $this->renderEsiFragment($request, 'lsc::shop.home.login-mobile-dropdown');
+    }
+
+    /**
+     * ESI: login drawer content for mobile.
+     */
+    public function esiLoginMobileDrawer(Request $request): Response
+    {
+        return $this->renderEsiFragment($request, 'lsc::shop.home.login-mobile-drawer');
     }
 
     /**

--- a/packages/Webkul/LSC/src/Http/Middleware/CustomerGroupCookie.php
+++ b/packages/Webkul/LSC/src/Http/Middleware/CustomerGroupCookie.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Webkul\LSC\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Cookie;
+use Webkul\LSC\Support\CartCacheContext;
+
+class CustomerGroupCookie
+{
+    /**
+     * Keep the unencrypted customer-group cookie in sync so LiteSpeed can vary
+     * the public cache per customer group (guest / general / wholesale).
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        $cookieName = CartCacheContext::groupCookieName();
+        $groupCode = CartCacheContext::currentGroupCode();
+
+        if ((string) $request->cookie($cookieName) !== $groupCode) {
+            $response->headers->setCookie(new Cookie(
+                $cookieName,
+                $groupCode,
+                strtotime('+5 years'),
+                '/',
+                config('session.domain'),
+                (bool) config('session.secure'),
+                false,
+                false,
+                config('session.same_site', 'lax')
+            ));
+        }
+
+        return $response;
+    }
+}

--- a/packages/Webkul/LSC/src/Http/Middleware/LSCacheHeaders.php
+++ b/packages/Webkul/LSC/src/Http/Middleware/LSCacheHeaders.php
@@ -6,6 +6,7 @@ use Closure;
 use Litespeed\LSCache\LSCacheMiddleware as BaseLSCacheMiddleware;
 use Webkul\Category\Repositories\CategoryRepository;
 use Webkul\CMS\Repositories\PageRepository;
+use Webkul\LSC\Support\CartCacheContext;
 use Webkul\LSC\Support\DebuggableLSCache as LSCache;
 use Webkul\LSC\Support\LiteSpeedDebug;
 use Webkul\Marketing\Repositories\URLRewriteRepository;
@@ -101,6 +102,7 @@ class LSCacheHeaders extends BaseLSCacheMiddleware
         $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate, private');
         $response->headers->set('X-LiteSpeed-Cache-Control', $lscacheControl);
         $response->headers->set('X-LiteSpeed-Tag', implode(',', $tags));
+        $response->headers->set('X-LiteSpeed-Vary', CartCacheContext::publicVaryHeader());
 
         return LiteSpeedDebug::attachToResponse($response, $tags, $lscacheControl);
     }
@@ -325,7 +327,7 @@ class LSCacheHeaders extends BaseLSCacheMiddleware
             return ['category-products_'.$categoryId];
         }
 
-        return [];
+        return ['product-listing'];
     }
 
     /**

--- a/packages/Webkul/LSC/src/Http/Middleware/LSCacheHeaders.php
+++ b/packages/Webkul/LSC/src/Http/Middleware/LSCacheHeaders.php
@@ -222,13 +222,7 @@ class LSCacheHeaders extends BaseLSCacheMiddleware
     {
         $cacheability = env('LSCACHE_DEFAULT_CACHEABILITY', 'public');
 
-        $control = "$cacheability, max-age=$ttl";
-
-        if (CartCacheContext::esiEnabled()) {
-            $control .= ',esi=on';
-        }
-
-        return $control;
+        return CartCacheContext::withEsi("$cacheability, max-age=$ttl");
     }
 
     /**
@@ -362,8 +356,15 @@ class LSCacheHeaders extends BaseLSCacheMiddleware
     {
         $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
 
-        $response->headers->set('X-LiteSpeed-Cache-Control', 'no-cache');
+        // The header layout is common to every page and carries the per-user
+        // <esi:include> fragments (login dropdown, cart count). LiteSpeed only
+        // assembles those when the response advertises esi=on, so emit it on
+        // non-cached pages too — see CartCacheContext::withEsi(). Without it the
+        // fragments leak unresolved on every route outside $cacheRoutes.
+        $lscacheControl = CartCacheContext::withEsi('no-cache');
 
-        return LiteSpeedDebug::attachToResponse($response, [], 'no-cache');
+        $response->headers->set('X-LiteSpeed-Cache-Control', $lscacheControl);
+
+        return LiteSpeedDebug::attachToResponse($response, [], $lscacheControl);
     }
 }

--- a/packages/Webkul/LSC/src/Http/Middleware/LSCacheHeaders.php
+++ b/packages/Webkul/LSC/src/Http/Middleware/LSCacheHeaders.php
@@ -212,12 +212,23 @@ class LSCacheHeaders extends BaseLSCacheMiddleware
 
     /**
      * Get cache control header value.
+     *
+     * When ESI is enabled, append `esi=on` so LiteSpeed parses the cached page
+     * body for <esi:include> tags and assembles the per-user fragments at the
+     * edge. (Ignored by OpenLiteSpeed, which has no ESI support — hence the
+     * esiEnabled() guard is only ever true on LiteSpeed Web Server Enterprise.)
      */
     private function getCacheControlHeader($ttl): string
     {
         $cacheability = env('LSCACHE_DEFAULT_CACHEABILITY', 'public');
 
-        return "$cacheability, max-age=$ttl";
+        $control = "$cacheability, max-age=$ttl";
+
+        if (CartCacheContext::esiEnabled()) {
+            $control .= ',esi=on';
+        }
+
+        return $control;
     }
 
     /**

--- a/packages/Webkul/LSC/src/Http/Middleware/PreventSensitiveRouteCaching.php
+++ b/packages/Webkul/LSC/src/Http/Middleware/PreventSensitiveRouteCaching.php
@@ -58,12 +58,18 @@ class PreventSensitiveRouteCaching
             return $response;
         }
 
+        // These sensitive pages (customer account, checkout, login, …) are never
+        // stored, but they still render the common header with its per-user
+        // <esi:include> fragments. Advertise esi=on so LiteSpeed assembles them;
+        // without it the login dropdown / cart count stay hidden here too.
+        $lscacheControl = CartCacheContext::withEsi('no-cache');
+
         $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0, private');
         $response->headers->set('Pragma', 'no-cache');
         $response->headers->set('Expires', '0');
-        $response->headers->set('X-LiteSpeed-Cache-Control', 'no-cache');
+        $response->headers->set('X-LiteSpeed-Cache-Control', $lscacheControl);
 
-        return LiteSpeedDebug::attachToResponse($response, [], 'no-cache');
+        return LiteSpeedDebug::attachToResponse($response, [], $lscacheControl);
     }
 
     /**

--- a/packages/Webkul/LSC/src/Http/Middleware/PrivateVaryCookie.php
+++ b/packages/Webkul/LSC/src/Http/Middleware/PrivateVaryCookie.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Webkul\LSC\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Cookie;
+use Webkul\LSC\Support\CartCacheContext;
+
+class PrivateVaryCookie
+{
+    /**
+     * Keep the unencrypted `lsc_private` vary cookie in sync with the current
+     * identity so LiteSpeed serves the correct private ESI fragments
+     * (login dropdown, cart-count badge) after login / logout.
+     *
+     * The private ESI fragments are stored keyed by `lsc_private`
+     * (X-LiteSpeed-Vary: cookie=lsc_private). That cookie is otherwise only
+     * emitted as a side effect of ESI / private-cart responses — which are
+     * served from cache (no PHP) on a hit, and whose Set-Cookie never reaches
+     * the browser when produced by an ESI sub-request. So on login/logout the
+     * browser keeps presenting the PREVIOUS identity's vary value and LiteSpeed
+     * keeps serving the previous identity's cached header fragment.
+     *
+     * This middleware is the private-cache counterpart of CustomerGroupCookie
+     * (which syncs the public vary `lsc_customer_group`): whenever the visitor's
+     * expected `lsc_private` value differs from what the browser sent, rewrite
+     * it. On the login/logout redirects — which are `no-cache` — this flips the
+     * cookie immediately, so the next navigation selects the correct ESI bucket.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        // Only meaningful while LSC private caching is active; otherwise the
+        // vary cookie has no consumer.
+        if (! CartCacheContext::privateCacheEnabled()) {
+            return $response;
+        }
+
+        // NEVER set this cookie on a publicly cacheable response. The public
+        // pages (home, product, category) are varied only by lsc_customer_group,
+        // NOT by lsc_private, so a Set-Cookie baked into that shared cache entry
+        // would hand one visitor's private vary to every other visitor in the
+        // same group — leaking their cart / account fragments. Auth transitions
+        // happen on no-cache responses, which are safe to write to.
+        $cacheControl = (string) $response->headers->get('X-LiteSpeed-Cache-Control');
+
+        if (str_contains($cacheControl, 'public')) {
+            return $response;
+        }
+
+        $cookieName = CartCacheContext::privateCookieName();
+        $expected = CartCacheContext::privateCookieValue($request);
+
+        if ((string) $request->cookie($cookieName) === $expected) {
+            return $response;
+        }
+
+        $response->headers->setCookie(new Cookie(
+            $cookieName,
+            $expected,
+            0,
+            '/',
+            config('session.domain'),
+            (bool) config('session.secure'),
+            false,
+            false,
+            config('session.same_site', 'lax')
+        ));
+
+        return $response;
+    }
+}

--- a/packages/Webkul/LSC/src/Http/Middleware/PurgeCartPrivateCache.php
+++ b/packages/Webkul/LSC/src/Http/Middleware/PurgeCartPrivateCache.php
@@ -24,7 +24,11 @@ class PurgeCartPrivateCache
             return $response;
         }
 
-        $privateTags = CartCacheContext::currentPrivateTags($request);
+        $privateTags = array_merge(
+            CartCacheContext::currentPrivateTags($request),
+            // ESI mini-cart count badge for the current context.
+            CartCacheContext::currentPrivateTagsForFamily('cart-count', ['cart-count'], $request)
+        );
         $urls = [
             '/api/checkout/cart',
             '/api/checkout/cart/cross-sell',

--- a/packages/Webkul/LSC/src/Listeners/Product.php
+++ b/packages/Webkul/LSC/src/Listeners/Product.php
@@ -54,7 +54,7 @@ class Product
     public function afterCreate($product)
     {
         try {
-            LSCache::purgeTags(array_merge(['home', 'search'], $this->getCategoryTags($product)));
+            LSCache::purgeTags(array_merge(['home', 'search', 'product-listing'], $this->getCategoryTags($product)));
 
             $this->deletePrivCache();
         } catch (\Throwable $e) {
@@ -128,7 +128,7 @@ class Product
      */
     public function getForgettableUrls($product, array $extraCategoryIds = [])
     {
-        $urls = ['search'];
+        $urls = ['search', 'product-listing'];
 
         $products = $this->getAllRelatedProducts($product);
 

--- a/packages/Webkul/LSC/src/Listeners/Session.php
+++ b/packages/Webkul/LSC/src/Listeners/Session.php
@@ -8,18 +8,24 @@ use Webkul\LSC\Support\DebuggableLSCache as LSCache;
 class Session
 {
     /**
-     * After page update
+     * Purge per-context private cache on customer login/logout.
      *
-     * @param  \Webkul\CMS\Contracts\Page  $page
+     * @param  \Webkul\Customer\Contracts\Customer|int|null  $customer
      * @return void
      */
     public function session($customer = null)
     {
         $customerId = is_object($customer) ? (int) ($customer->id ?? 0) : (int) $customer;
 
+        // Login/logout flips auth state, so also evict the ESI login fragments
+        // and the cart-count badge for both the guest and customer contexts.
+        $esiScopes = ['login', 'cart-count'];
+
         $tags = array_merge(
             CartCacheContext::guestPrivateTags(request()),
-            $customerId > 0 ? CartCacheContext::customerPrivateTags($customerId) : []
+            CartCacheContext::guestPrivateTagsForFamily('esi', $esiScopes, request()),
+            $customerId > 0 ? CartCacheContext::customerPrivateTags($customerId) : [],
+            $customerId > 0 ? CartCacheContext::customerPrivateTagsForFamily('esi', $customerId, $esiScopes) : []
         );
 
         LSCache::purgePrivateTags($tags);

--- a/packages/Webkul/LSC/src/Providers/LSCServiceProvider.php
+++ b/packages/Webkul/LSC/src/Providers/LSCServiceProvider.php
@@ -73,7 +73,18 @@ class LSCServiceProvider extends ServiceProvider
 
         $this->publishFiles();
 
-        if (core()->getConfigData('lsc.configuration.cache_application.active')) {
+        // Guard the boot-time DB read. core()->getConfigData() resolves the current channel
+        // from the database; on a not-yet-installed store the channels table is missing
+        // (before migrations) or empty (after migrations, before seeding), and getCurrentChannelCode()
+        // then returns null against a string return type — a fatal that would break every
+        // artisan command (migrate, install, seed). Swallow it until the store is installed.
+        try {
+            $lscActive = (bool) core()->getConfigData('lsc.configuration.cache_application.active');
+        } catch (\Throwable $e) {
+            return;
+        }
+
+        if ($lscActive) {
             $this->manageConfigMenus();
         }
     }

--- a/packages/Webkul/LSC/src/Providers/LSCServiceProvider.php
+++ b/packages/Webkul/LSC/src/Providers/LSCServiceProvider.php
@@ -11,6 +11,7 @@ use Webkul\Admin\Http\Controllers\Settings\ThemeController as BaseThemeControlle
 use Webkul\Core\Http\Middleware\PreventRequestsDuringMaintenance;
 use Webkul\LSC\Http\Controllers\Admin\Catalog\CategoryController;
 use Webkul\LSC\Http\Controllers\Admin\Settings\ThemeController;
+use Webkul\LSC\Http\Middleware\CustomerGroupCookie;
 use Webkul\LSC\Http\Middleware\LSCacheHeaders;
 use Webkul\LSC\Http\Middleware\NoLiteSpeedCache;
 use Webkul\LSC\Http\Middleware\PrivateCartCache;
@@ -25,7 +26,7 @@ class LSCServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        EncryptCookies::except('lsc_private');
+        EncryptCookies::except(['lsc_private', 'lsc_customer_group']);
 
         $this->registerConfig();
 
@@ -46,6 +47,8 @@ class LSCServiceProvider extends ServiceProvider
         $this->app->register(EventServiceProvider::class);
 
         $router->pushMiddlewareToGroup('web', PreventSensitiveRouteCaching::class);
+
+        $router->pushMiddlewareToGroup('web', CustomerGroupCookie::class);
 
         Route::middleware('web')->group(__DIR__.'/../Routes/admin/lsc-auth-routes.php');
 

--- a/packages/Webkul/LSC/src/Providers/LSCServiceProvider.php
+++ b/packages/Webkul/LSC/src/Providers/LSCServiceProvider.php
@@ -16,6 +16,7 @@ use Webkul\LSC\Http\Middleware\LSCacheHeaders;
 use Webkul\LSC\Http\Middleware\NoLiteSpeedCache;
 use Webkul\LSC\Http\Middleware\PrivateCartCache;
 use Webkul\LSC\Http\Middleware\PrivateCompareCache;
+use Webkul\LSC\Http\Middleware\PrivateVaryCookie;
 use Webkul\LSC\Http\Middleware\PrivateWishlistCache;
 use Webkul\LSC\Http\Middleware\PreventSensitiveRouteCaching;
 
@@ -45,6 +46,11 @@ class LSCServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../Resources/views', 'lsc');
 
         $this->app->register(EventServiceProvider::class);
+
+        // Outermost of the LSC web middleware so its unwinding pass can read the
+        // final X-LiteSpeed-Cache-Control (set by PreventSensitiveRouteCaching /
+        // LSCacheHeaders) when deciding whether the response is publicly cached.
+        $router->pushMiddlewareToGroup('web', PrivateVaryCookie::class);
 
         $router->pushMiddlewareToGroup('web', PreventSensitiveRouteCaching::class);
 

--- a/packages/Webkul/LSC/src/Resources/views/shop/checkout/cart/mini-cart.blade.php
+++ b/packages/Webkul/LSC/src/Resources/views/shop/checkout/cart/mini-cart.blade.php
@@ -1,0 +1,475 @@
+{{--
+    LSC override of shop::checkout.cart.mini-cart.
+
+    Only the pre-mount placeholder slot below is changed: when ESI is enabled it
+    seeds the cart-count badge server-side (via <esi:include>) for an instant
+    first paint, then the v-mini-cart Vue component mounts over it and takes over
+    live, in-page updates. The rest of the file is identical to the core view.
+--}}
+<!-- Mini Cart Vue Component -->
+<v-mini-cart>
+    <span class="relative">
+        <span
+            class="icon-cart cursor-pointer text-2xl"
+            role="button"
+            aria-label="@lang('shop::app.checkout.cart.mini-cart.shopping-cart')"
+        ></span>
+
+        @if (\Webkul\LSC\Support\CartCacheContext::esiEnabled())
+            <esi:include src='{{ route('shop.api.home.esi.cart_count', [], false) }}' cache-control='private' cache-tag='cart-count' />
+        @endif
+    </span>
+</v-mini-cart>
+
+@pushOnce('scripts')
+    <script
+        type="text/x-template"
+        id="v-mini-cart-template"
+    >
+        {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.before') !!}
+
+        @if (core()->getConfigData('sales.checkout.mini_cart.display_mini_cart'))
+            <x-shop::drawer>
+                <!-- Drawer Toggler -->
+                <x-slot:toggle>
+                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.toggle.before') !!}
+
+                    <span class="relative">
+                        <span
+                            class="icon-cart cursor-pointer text-2xl"
+                            role="button"
+                            aria-label="@lang('shop::app.checkout.cart.mini-cart.shopping-cart')"
+                            tabindex="0"
+                        ></span>
+
+                        @if (core()->getConfigData('sales.checkout.my_cart.summary') == 'display_item_quantity')
+                            <span
+                                class="absolute -top-4 rounded-[44px] bg-navyBlue px-2 py-1.5 text-xs font-semibold leading-[9px] text-white ltr:left-5 rtl:right-5 max-md:ltr:left-4 max-md:rtl:right-4"
+                                v-if="cart?.items_qty"
+                            >
+                                @{{ cart.items_qty }}
+                            </span>
+                        @else
+                            <span
+                                class="absolute -top-4 rounded-[44px] bg-navyBlue px-2 py-1.5 text-xs font-semibold leading-[9px] text-white ltr:left-5 rtl:right-5 max-md:px-2 max-md:py-1.5 max-md:ltr:left-4 max-md:rtl:right-4"
+                                v-if="cart?.items_count"
+                            >
+                                @{{ cart.items_count }}
+                            </span>
+                        @endif
+                    </span>
+
+                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.toggle.after') !!}
+                </x-slot>
+
+                <!-- Drawer Header -->
+                <x-slot:header>
+                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.header.before') !!}
+
+                    <div class="flex items-center justify-between">
+                        <p class="text-2xl font-medium max-md:text-xl max-sm:text-xl">
+                            @lang('shop::app.checkout.cart.mini-cart.shopping-cart')
+                        </p>
+                    </div>
+
+                    <p class="text-base max-md:text-zinc-500 max-sm:text-xs">
+                        {{ core()->getConfigData('sales.checkout.mini_cart.offer_info')}}
+                    </p>
+
+                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.header.after') !!}
+                </x-slot>
+
+                <!-- Drawer Content -->
+                <x-slot:content>
+                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.before') !!}
+
+                    <!-- Cart Item Listing -->
+                    <div
+                        class="mt-9 grid gap-12 max-md:mt-2.5 max-md:gap-5"
+                        v-if="cart?.items?.length"
+                    >
+                        <div
+                            class="flex gap-x-5 max-md:gap-x-4"
+                            v-for="item in cart?.items"
+                        >
+                            <!-- Cart Item Image -->
+                            {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.image.before') !!}
+
+                            <div class="">
+                                <a :href="`{{ route('shop.product_or_category.index', '') }}/${item.product_url_key}`">
+                                    <img
+                                        :src="item.base_image.small_image_url"
+                                        class="max-w-28 max-h-28 rounded-xl max-md:max-h-20 max-md:max-w-[76px]"
+                                    />
+                                </a>
+                            </div>
+
+                            {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.image.after') !!}
+
+                        <!-- Cart Item Information -->
+                        <div class="grid flex-1 place-content-start justify-stretch gap-y-2.5">
+                            <div class="flex justify-between gap-2 max-md:gap-0 max-sm:flex-wrap">
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.name.before') !!}
+
+                                    <a
+                                    class="max-w-4/5 max-md:w-full"
+                                    :href="`{{ route('shop.product_or_category.index', '') }}/${item.product_url_key}`"
+                                >
+                                        <p class="text-base font-medium max-md:font-normal max-sm:text-sm">
+                                            @{{ item.name }}
+                                        </p>
+                                    </a>
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.name.after') !!}
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.price.before') !!}
+
+                                    <template v-if="displayTax.prices == 'including_tax'">
+                                        <p class="text-lg max-md:font-semibold max-sm:text-sm">
+                                            @{{ item.formatted_price_incl_tax }}
+                                        </p>
+                                    </template>
+
+                                    <template v-else-if="displayTax.prices == 'both'">
+                                        <p class="flex flex-col text-lg max-md:font-semibold max-sm:text-sm">
+                                            @{{ item.formatted_price_incl_tax }}
+
+                                            <span class="text-xs font-normal text-zinc-500">
+                                                @lang('shop::app.checkout.cart.mini-cart.excl-tax')
+
+                                                <span class="font-medium text-black">@{{ item.formatted_price }}</span>
+                                            </span>
+                                        </p>
+                                    </template>
+
+                                    <template v-else>
+                                        <p class="text-lg max-md:font-semibold max-sm:text-sm">
+                                            @{{ item.formatted_price }}
+                                        </p>
+                                    </template>
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.price.after') !!}
+                                </div>
+
+                                <!-- Cart Item Options Container -->
+                                <div
+                                    class="grid select-none gap-x-2.5 gap-y-1.5 max-sm:gap-y-0.5"
+                                    v-if="item.options.length"
+                                >
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.product_details.before') !!}
+
+                                    <!-- Details Toggler -->
+                                    <div class="">
+                                        <p
+                                            class="flex cursor-pointer items-center gap-x-4 text-base max-md:gap-x-1.5 max-md:text-sm max-sm:text-xs"
+                                            @click="item.option_show = ! item.option_show"
+                                        >
+                                            @lang('shop::app.checkout.cart.mini-cart.see-details')
+
+                                            <span
+                                                class="text-2xl max-md:text-xl max-sm:text-lg"
+                                                :class="{'icon-arrow-up': item.option_show, 'icon-arrow-down': ! item.option_show}"
+                                            ></span>
+                                        </p>
+                                    </div>
+
+                                    <!-- Option Details -->
+                                    <div
+                                        class="grid gap-2"
+                                        v-show="item.option_show"
+                                    >
+                                        <template v-for="attribute in item.options">
+                                            <div class="max-md:grid max-md:gap-0.5">
+                                                <p class="text-sm font-medium text-zinc-500 max-md:font-normal max-sm:text-xs">
+                                                    @{{ attribute.attribute_name + ':' }}
+                                                </p>
+
+                                                <p class="text-sm max-sm:text-xs">
+                                                    <template v-if="attribute?.attribute_type === 'file'">
+                                                        <a
+                                                            :href="attribute.file_url"
+                                                            class="text-blue-700"
+                                                            target="_blank"
+                                                            :download="attribute.file_name"
+                                                        >
+                                                            @{{ attribute.file_name }}
+                                                        </a>
+                                                    </template>
+
+                                                    <template v-else>
+                                                        @{{ attribute.option_label }}
+                                                    </template>
+                                                </p>
+                                            </div>
+                                        </template>
+                                    </div>
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.product_details.after') !!}
+                                </div>
+
+                                <div class="flex flex-wrap items-center gap-5 max-md:gap-2.5">
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.quantity_changer.before') !!}
+
+                                <!-- Cart Item Quantity Changer -->
+                                <x-shop::quantity-changer
+                                    class="max-h-9 max-w-[150px] gap-x-2.5 rounded-[54px] px-3.5 py-1.5 max-md:gap-x-2 max-md:px-1 max-md:py-0.5"
+                                    name="quantity"
+                                    ::value="item?.quantity"
+                                    @change="updateItem($event, item)"
+                                />
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.quantity_changer.after') !!}
+
+                                {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.remove_button.before') !!}
+
+                                <!-- Cart Item Remove Button -->
+                                <button
+                                    type="button"
+                                    class="text-blue-700 max-md:text-sm"
+                                    @click="removeItem(item.id)"
+                                >
+                                    @lang('shop::app.checkout.cart.mini-cart.remove')
+                                </button>
+
+                                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.remove_button.after') !!}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Empty Cart Section -->
+                    <div
+                        class="mt-32 pb-8 max-md:mt-32"
+                        v-else
+                    >
+                        <div class="b-0 grid place-items-center gap-y-5 max-md:gap-y-0">
+                            <img
+                                class="max-md:h-[100px] max-md:w-[100px]"
+                                src="{{ bagisto_asset('images/thank-you.png') }}"
+                            >
+
+                            <p
+                                class="text-xl max-md:text-sm"
+                                role="heading"
+                            >
+                                @lang('shop::app.checkout.cart.mini-cart.empty-cart')
+                            </p>
+                        </div>
+                    </div>
+
+                    {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.content.after') !!}
+                </x-slot>
+
+            <!-- Drawer Footer -->
+            <x-slot:footer>
+                <div
+                    v-if="cart?.items?.length"
+                    class="grid-col-1 grid gap-5 max-md:gap-2.5"
+                >
+                    <div
+                        class="my-8 flex items-center justify-between border-b border-zinc-200 px-6 pb-2 max-md:my-0 max-md:border-t max-md:px-5 max-md:py-2"
+                        :class="{'!justify-end': isLoading}"
+                    >
+                        {!! view_render_event('bagisto.shop.checkout.mini-cart.subtotal.before') !!}
+
+                        <template v-if="! isLoading">
+                            <p class="text-sm font-medium text-zinc-500">
+                                @lang('shop::app.checkout.cart.mini-cart.subtotal')
+                            </p>
+
+                        <template v-if="displayTax.subtotal == 'including_tax'">
+                            <p class="text-3xl font-semibold max-md:text-base">
+                                @{{ cart.formatted_sub_total_incl_tax }}
+                            </p>
+                        </template>
+
+                        <template v-else-if="displayTax.subtotal == 'both'">
+                            <p class="flex flex-col text-3xl font-semibold max-md:text-sm max-sm:text-right">
+                                @{{ cart.formatted_sub_total_incl_tax }}
+
+                                <span class="text-sm font-normal text-zinc-500 max-sm:text-xs">
+                                    @lang('shop::app.checkout.cart.mini-cart.excl-tax')
+
+                                    <span class="font-medium text-black">@{{ cart.formatted_sub_total }}</span>
+                                </span>
+                            </p>
+                        </template>
+
+                        <template v-else>
+                            <p class="text-3xl font-semibold max-md:text-base">
+                                @{{ cart.formatted_sub_total }}
+                            </p>
+                        </template>
+                    </template>
+
+                        <template v-else>
+                            <!-- Spinner -->
+                            <svg
+                                class="text-blue h-8 w-8 animate-spin text-[5px] font-semibold max-md:h-7 max-md:w-7 max-sm:h-4 max-sm:w-4"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                aria-hidden="true"
+                                viewBox="0 0 24 24"
+                            >
+                                <circle
+                                    class="opacity-25"
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    stroke="currentColor"
+                                    stroke-width="4"
+                                ></circle>
+
+                                <path
+                                    class="opacity-75"
+                                    fill="currentColor"
+                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                ></path>
+                            </svg>
+                        </template>
+
+                            {!! view_render_event('bagisto.shop.checkout.mini-cart.subtotal.after') !!}
+                        </div>
+
+                        {!! view_render_event('bagisto.shop.checkout.mini-cart.action.before') !!}
+
+                        <!-- Cart Action Container -->
+                        <div class="grid gap-2.5 px-6 max-md:px-4 max-sm:gap-1.5">
+                            {!! view_render_event('bagisto.shop.checkout.mini-cart.continue_to_checkout.before') !!}
+
+                        <a
+                            href="{{ route('shop.checkout.onepage.index') }}"
+                            class="mx-auto block w-full cursor-pointer rounded-2xl bg-navyBlue px-11 py-4 text-center text-base font-medium text-white max-md:rounded-lg max-md:px-5 max-md:py-2"
+                        >
+                            @lang('shop::app.checkout.cart.mini-cart.continue-to-checkout')
+                        </a>
+
+                            {!! view_render_event('bagisto.shop.checkout.mini-cart.continue_to_checkout.after') !!}
+
+                            <div class="block cursor-pointer text-center text-base font-medium max-md:py-1.5">
+                                <a href="{{ route('shop.checkout.cart.index') }}">
+                                    @lang('shop::app.checkout.cart.mini-cart.view-cart')
+                                </a>
+                            </div>
+                        </div>
+
+                        {!! view_render_event('bagisto.shop.checkout.mini-cart.action.after') !!}
+                    </div>
+                </x-slot>
+            </x-shop::drawer>
+
+        @else
+            <a href="{{ route('shop.checkout.onepage.index') }}">
+                {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.toggle.before') !!}
+
+                    <span class="relative">
+                        <span
+                            class="icon-cart cursor-pointer text-2xl"
+                            role="button"
+                            aria-label="@lang('shop::app.checkout.cart.mini-cart.shopping-cart')"
+                            tabindex="0"
+                        ></span>
+
+                        <span
+                            class="absolute -top-4 rounded-[44px] bg-navyBlue px-2 py-1.5 text-xs font-semibold leading-[9px] text-white ltr:left-5 rtl:right-5 max-md:px-2 max-md:py-1.5 max-md:ltr:left-4 max-md:rtl:right-4"
+                            v-if="cart?.items_qty"
+                        >
+                            @{{ cart.items_qty }}
+                        </span>
+                    </span>
+
+                {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.toggle.after') !!}
+            </a>
+        @endif
+
+        {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.after') !!}
+    </script>
+
+    <script type="module">
+        app.component("v-mini-cart", {
+            template: '#v-mini-cart-template',
+
+            data() {
+                return  {
+                    cart: null,
+
+                    isLoading:false,
+
+                    displayTax: {
+                        prices: "{{ core()->getConfigData('sales.taxes.shopping_cart.display_prices') }}",
+                        subtotal: "{{ core()->getConfigData('sales.taxes.shopping_cart.display_subtotal') }}",
+                    },
+                }
+            },
+
+            mounted() {
+                this.getCart();
+
+                /**
+                 * To Do: Implement this.
+                 *
+                 * Action.
+                 */
+                this.$emitter.on('update-mini-cart', (cart) => {
+                    this.cart = cart;
+                });
+            },
+
+            methods: {
+                getCart() {
+                    this.$axios.get('{{ route('shop.api.checkout.cart.index') }}')
+                        .then(response => {
+                            this.cart = response.data.data;
+                        })
+                        .catch(error => {});
+                },
+
+                updateItem(quantity, item) {
+                    this.isLoading = true;
+
+                    let qty = {};
+
+                    qty[item.id] = quantity;
+
+                    this.$axios.put('{{ route('shop.api.checkout.cart.update') }}', { qty })
+                        .then(response => {
+                            if (response.data.message) {
+                                this.cart = response.data.data;
+                            } else {
+                                this.$emitter.emit('add-flash', { type: 'warning', message: response.data.data.message });
+                            }
+
+                            this.isLoading = false;
+                        }).catch(error => this.isLoading = false);
+                },
+
+                removeItem(itemId) {
+                    this.$emitter.emit('open-confirm-modal', {
+                        agree: () => {
+                            this.isLoading = true;
+
+                            this.$axios.post('{{ route('shop.api.checkout.cart.destroy') }}', {
+                                '_method': 'DELETE',
+                                'cart_item_id': itemId,
+                            })
+                            .then(response => {
+                                this.cart = response.data.data;
+
+                                this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
+
+                                this.isLoading = false;
+                            })
+                            .catch(error => {
+                                this.$emitter.emit('add-flash', { type: 'error', message: response.data.message });
+
+                                this.isLoading = false;
+                            });
+                        }
+                    });
+                },
+            },
+        });
+    </script>
+@endpushOnce

--- a/packages/Webkul/LSC/src/Resources/views/shop/components/layouts/header/desktop/bottom.blade.php
+++ b/packages/Webkul/LSC/src/Resources/views/shop/components/layouts/header/desktop/bottom.blade.php
@@ -136,7 +136,12 @@
                 </x-slot>
 
                 <x-slot:content>
-                    <v-login-desktop-dropdown />
+                    @if (\Webkul\LSC\Support\CartCacheContext::esiEnabled())
+                        {{-- ESI: LiteSpeed assembles the per-user login dropdown at the edge (no AJAX flash) --}}
+                        <esi:include src='{{ route('shop.api.home.esi.login_desktop_dropdown', [], false) }}' cache-control='private' cache-tag='login' />
+                    @else
+                        <v-login-desktop-dropdown />
+                    @endif
                 </x-slot:content>
             </x-shop::dropdown>
 

--- a/packages/Webkul/LSC/src/Resources/views/shop/components/layouts/header/mobile/index.blade.php
+++ b/packages/Webkul/LSC/src/Resources/views/shop/components/layouts/header/mobile/index.blade.php
@@ -67,7 +67,12 @@
                         </x-slot>
 
                         <x-slot:content>
-                            <v-login-mobile-dropdown showWishlist="{{ $showWishlist }}"></v-login-mobile-dropdown>
+                            @if (\Webkul\LSC\Support\CartCacheContext::esiEnabled())
+                                {{-- ESI: LiteSpeed assembles the per-user login dropdown at the edge --}}
+                                <esi:include src='{{ route('shop.api.home.esi.login_mobile_dropdown', [], false) }}' cache-control='private' cache-tag='login' />
+                            @else
+                                <v-login-mobile-dropdown showWishlist="{{ $showWishlist }}"></v-login-mobile-dropdown>
+                            @endif
                         </x-slot:content>
                     </x-shop::dropdown>
                 </div>
@@ -159,7 +164,7 @@
 
             <x-slot:content class="!p-0">
                 <!-- Account Profile Hero Section -->
-                <div ref="lsc_mobile_drawer"></div>
+                <div ref="lsc_mobile_drawer">@if (\Webkul\LSC\Support\CartCacheContext::esiEnabled())<esi:include src='{{ route('shop.api.home.esi.login_mobile_drawer', [], false) }}' cache-control='private' cache-tag='login' />@endif</div>
 
                 {!! view_render_event('bagisto.shop.components.layouts.header.mobile.drawer.categories.before') !!}
 
@@ -447,7 +452,9 @@
             template: '#v-mobile-drawer-template',
 
             mounted() {
-                this.getLoginMobileDrawer();
+                @if (! \Webkul\LSC\Support\CartCacheContext::esiEnabled())
+                    this.getLoginMobileDrawer();
+                @endif
             },
 
             methods: {

--- a/packages/Webkul/LSC/src/Resources/views/shop/home/cart-count.blade.php
+++ b/packages/Webkul/LSC/src/Resources/views/shop/home/cart-count.blade.php
@@ -1,0 +1,11 @@
+@php
+    $summary = core()->getConfigData('sales.checkout.my_cart.summary');
+
+    $count = $summary === 'display_item_quantity' ? ($itemsQty ?? 0) : ($itemsCount ?? 0);
+@endphp
+
+@if ($count > 0)
+    <span class="absolute -top-4 rounded-[44px] bg-navyBlue px-2 py-1.5 text-xs font-semibold leading-[9px] text-white ltr:left-5 rtl:right-5 max-md:px-2 max-md:py-1.5 max-md:ltr:left-4 max-md:rtl:right-4">
+        {{ $count }}
+    </span>
+@endif

--- a/packages/Webkul/LSC/src/Resources/views/shop/home/login-mobile-dropdown.blade.php
+++ b/packages/Webkul/LSC/src/Resources/views/shop/home/login-mobile-dropdown.blade.php
@@ -72,13 +72,14 @@
                 @lang('shop::app.components.layouts.header.mobile.orders')
             </a>
             
-            <a
-                v-if="showWishlist"
-                class="cursor-pointer px-5 py-2 text-base"
-                href="{{ route('shop.customers.account.wishlist.index') }}"
-            >
-                @lang('shop::app.components.layouts.header.mobile.wishlist')
-            </a>
+            @if (core()->getConfigData('customer.settings.wishlist.wishlist_option'))
+                <a
+                    class="cursor-pointer px-5 py-2 text-base"
+                    href="{{ route('shop.customers.account.wishlist.index') }}"
+                >
+                    @lang('shop::app.components.layouts.header.mobile.wishlist')
+                </a>
+            @endif
 
             <!--Customers logout-->
             @auth('customer')

--- a/packages/Webkul/LSC/src/Routes/api.php
+++ b/packages/Webkul/LSC/src/Routes/api.php
@@ -1,11 +1,15 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Webkul\LSC\Http\Controllers\API\CartCountController;
 use Webkul\LSC\Http\Controllers\API\LoginContentController;
 use Webkul\LSC\Http\Middleware\NoLiteSpeedCache;
 
 /**
- * Login content routes.
+ * Login content routes (AJAX/Vue fallback path).
+ *
+ * Returns JSON and is never LiteSpeed-cached; the storefront injects the HTML
+ * via innerHTML when ESI is disabled (e.g. OpenLiteSpeed / local dev).
  */
 Route::group(['middleware' => [NoLiteSpeedCache::class], 'prefix' => 'api'], function () {
     Route::controller(LoginContentController::class)->group(function () {
@@ -18,4 +22,28 @@ Route::group(['middleware' => [NoLiteSpeedCache::class], 'prefix' => 'api'], fun
         Route::get('login-mobile-drawer', 'getLoginMobileDrawerHtml')
             ->name('shop.api.home.login_mobile_drawer');
     });
+});
+
+/**
+ * ESI fragment routes (LiteSpeed Web Server Enterprise path).
+ *
+ * These return raw HTML and set their OWN private-cache headers, so they must
+ * NOT carry NoLiteSpeedCache (which would force no-cache). PreventSensitiveRouteCaching
+ * passes these `api/esi/*` routes through untouched, so the controller's
+ * private headers reach LiteSpeed and each fragment is cached per-user.
+ */
+Route::group(['prefix' => 'api/esi'], function () {
+    Route::controller(LoginContentController::class)->group(function () {
+        Route::get('login-desktop-dropdown', 'esiLoginDesktopDropdown')
+            ->name('shop.api.home.esi.login_desktop_dropdown');
+
+        Route::get('login-mobile-dropdown', 'esiLoginMobileDropdown')
+            ->name('shop.api.home.esi.login_mobile_dropdown');
+
+        Route::get('login-mobile-drawer', 'esiLoginMobileDrawer')
+            ->name('shop.api.home.esi.login_mobile_drawer');
+    });
+
+    Route::get('cart-count', [CartCountController::class, 'index'])
+        ->name('shop.api.home.esi.cart_count');
 });

--- a/packages/Webkul/LSC/src/Support/CartCacheContext.php
+++ b/packages/Webkul/LSC/src/Support/CartCacheContext.php
@@ -52,6 +52,26 @@ class CartCacheContext
     }
 
     /**
+     * Append the ESI assembly flag to a LiteSpeed cache-control value.
+     *
+     * Every page LiteSpeed serves — public (home, product, category), no-cache
+     * (account, checkout) or privately cached (cart, compare, wishlist) — still
+     * renders the common header, which carries the per-user <esi:include>
+     * fragments (login dropdown, cart count). LiteSpeed only assembles those
+     * fragments when the parent response advertises esi=on, so the flag must be
+     * present on EVERY response variant, not just the publicly cached ones.
+     *
+     * Centralising it here keeps every cache-control call site from drifting
+     * apart: LSCacheHeaders (cached + no-cache paths), PreventSensitiveRouteCaching
+     * (sensitive/account pages) and the three Private*Cache classes (cart,
+     * compare, wishlist).
+     */
+    public static function withEsi(string $cacheControl): string
+    {
+        return self::esiEnabled() ? $cacheControl.',esi=on' : $cacheControl;
+    }
+
+    /**
      * Resolve the cart private cache TTL.
      */
     public static function privateTtl(): int

--- a/packages/Webkul/LSC/src/Support/CartCacheContext.php
+++ b/packages/Webkul/LSC/src/Support/CartCacheContext.php
@@ -244,4 +244,28 @@ class CartCacheContext
 
         return array_values(array_unique(array_filter($tags)));
     }
+
+    /**
+     * Build catalog content tags ("product_{id}") for a set of product ids.
+     *
+     * These reuse the same tag namespace emitted on public product pages, so
+     * the existing Product listener purge — LSCache::purgeTags(['product_{id}'])
+     * — also evicts any private cart / wishlist / compare entry displaying the
+     * product. This keeps those private caches in sync with catalog price /
+     * data changes without any extra listener code.
+     */
+    public static function productTags(array $productIds): array
+    {
+        $tags = [];
+
+        foreach ($productIds as $id) {
+            $id = (int) $id;
+
+            if ($id > 0) {
+                $tags['product_'.$id] = 'product_'.$id;
+            }
+        }
+
+        return array_values($tags);
+    }
 }

--- a/packages/Webkul/LSC/src/Support/CartCacheContext.php
+++ b/packages/Webkul/LSC/src/Support/CartCacheContext.php
@@ -12,6 +12,16 @@ class CartCacheContext
     private const PRIVATE_COOKIE = 'lsc_private';
 
     /**
+     * Unencrypted cookie used to vary public cache by customer group.
+     */
+    private const GROUP_COOKIE = 'lsc_customer_group';
+
+    /**
+     * Customer group code used for unauthenticated visitors.
+     */
+    private const GUEST_GROUP = 'guest';
+
+    /**
      * Cart-specific private cache scopes that should move together.
      */
     private const SCOPES = [
@@ -61,6 +71,36 @@ class CartCacheContext
     }
 
     /**
+     * The unencrypted cookie name used to vary public cache by customer group.
+     */
+    public static function groupCookieName(): string
+    {
+        return self::GROUP_COOKIE;
+    }
+
+    /**
+     * Resolve the customer group code for the current visitor.
+     */
+    public static function currentGroupCode(): string
+    {
+        $customer = auth()->guard('customer')->user();
+
+        return $customer?->group?->code ?: self::GUEST_GROUP;
+    }
+
+    /**
+     * Vary header for public cached pages: customer group, locale and currency.
+     */
+    public static function publicVaryHeader(): string
+    {
+        return 'cookie='.implode(',', [
+            self::GROUP_COOKIE,
+            'bagisto_locale',
+            'bagisto_currency',
+        ]);
+    }
+
+    /**
      * Stable private cookie value for the current cart context.
      */
     public static function privateCookieValue(?Request $request = null): string
@@ -106,49 +146,46 @@ class CartCacheContext
     }
 
     /**
-     * Route-specific tags plus the shared cart tags for the active context.
+     * Single route-scoped tag for the active context.
      */
     public static function responseTags(string $scope, ?Request $request = null): array
     {
-        $contextKey = self::responseContextKey($request);
-
-        return self::privateTagsForContext($contextKey, ['cart-private', $scope]);
+        return self::privateTagsForContext(self::responseContextKey($request), [$scope]);
     }
 
     /**
-     * Build private tags for an arbitrary private-cache family and scope.
+     * Single route-scoped tag for an arbitrary private-cache family.
+     *
+     * The $family parameter is retained for call-site compatibility but no
+     * longer produces a tag — one tag per route/scope is emitted instead.
      */
     public static function responseTagsForFamily(string $family, string $scope, ?Request $request = null): array
     {
-        $contextKey = self::responseContextKey($request);
-
-        return self::privateTagsForContext($contextKey, [$family, $scope]);
+        return self::privateTagsForContext(self::responseContextKey($request), [$scope]);
     }
 
     /**
-     * Current-context tags for an arbitrary private-cache family and scopes.
+     * Current-context tags for the given private-cache scopes.
      */
     public static function currentPrivateTagsForFamily(string $family, array $scopes, ?Request $request = null): array
     {
-        $contextKey = self::currentContextKey($request);
-
-        return self::privateTagsForContext($contextKey, array_merge([$family], $scopes));
+        return self::privateTagsForContext(self::currentContextKey($request), $scopes);
     }
 
     /**
-     * Customer-context tags for an arbitrary private-cache family and scopes.
+     * Customer-context tags for the given private-cache scopes.
      */
     public static function customerPrivateTagsForFamily(string $family, int $customerId, array $scopes): array
     {
-        return self::privateTagsForContext('customer_'.$customerId, array_merge([$family], $scopes));
+        return self::privateTagsForContext('customer_'.$customerId, $scopes);
     }
 
     /**
-     * Guest-context tags for an arbitrary private-cache family and scopes.
+     * Guest-context tags for the given private-cache scopes.
      */
     public static function guestPrivateTagsForFamily(string $family, array $scopes, ?Request $request = null): array
     {
-        return self::privateTagsForContext(self::guestContextKey($request), array_merge([$family], $scopes));
+        return self::privateTagsForContext(self::guestContextKey($request), $scopes);
     }
 
     /**
@@ -193,13 +230,15 @@ class CartCacheContext
 
     /**
      * Expand scopes into private cache tags.
+     *
+     * One tag per route/scope: "{scope}-{contextKey}". The context key already
+     * isolates per customer/guest, so a shared family tag is not needed.
      */
     private static function privateTagsForContext(string $contextKey, array $scopes): array
     {
         $tags = [];
 
         foreach ($scopes as $scope) {
-            $tags[] = $scope;
             $tags[] = $scope.'-'.$contextKey;
         }
 

--- a/packages/Webkul/LSC/src/Support/CartCacheContext.php
+++ b/packages/Webkul/LSC/src/Support/CartCacheContext.php
@@ -39,6 +39,19 @@ class CartCacheContext
     }
 
     /**
+     * Determine whether ESI (Edge Side Includes) should be used.
+     *
+     * Requires both the ESI flag (LSCACHE_ESI_ENABLED, only meaningful on
+     * LiteSpeed Web Server Enterprise — OpenLiteSpeed has no ESI support) and
+     * LSC itself to be active. Templates branch on this to emit <esi:include>
+     * tags instead of the AJAX/Vue hole-punching fallback.
+     */
+    public static function esiEnabled(): bool
+    {
+        return (bool) config('lscache.esi') && self::privateCacheEnabled();
+    }
+
+    /**
      * Resolve the cart private cache TTL.
      */
     public static function privateTtl(): int

--- a/packages/Webkul/LSC/src/Support/PrivateCartCache.php
+++ b/packages/Webkul/LSC/src/Support/PrivateCartCache.php
@@ -18,7 +18,7 @@ class PrivateCartCache
             CartCacheContext::responseTags($scope, $request),
             self::productTags()
         );
-        $cacheControl = 'private,max-age='.$ttl;
+        $cacheControl = CartCacheContext::withEsi('private,max-age='.$ttl);
         $privateCookieName = CartCacheContext::privateCookieName();
         $privateCookieValue = CartCacheContext::privateCookieValue($request);
 

--- a/packages/Webkul/LSC/src/Support/PrivateCartCache.php
+++ b/packages/Webkul/LSC/src/Support/PrivateCartCache.php
@@ -4,6 +4,7 @@ namespace Webkul\LSC\Support;
 
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Cookie;
+use Webkul\Checkout\Facades\Cart;
 
 class PrivateCartCache
 {
@@ -13,7 +14,10 @@ class PrivateCartCache
     public static function apply(mixed $response, Request $request, string $scope): mixed
     {
         $ttl = CartCacheContext::privateTtl();
-        $tags = CartCacheContext::responseTags($scope, $request);
+        $tags = array_merge(
+            CartCacheContext::responseTags($scope, $request),
+            self::productTags()
+        );
         $cacheControl = 'private,max-age='.$ttl;
         $privateCookieName = CartCacheContext::privateCookieName();
         $privateCookieValue = CartCacheContext::privateCookieValue($request);
@@ -37,6 +41,38 @@ class PrivateCartCache
         ));
 
         return LiteSpeedDebug::attachToResponse($response, $tags, $cacheControl);
+    }
+
+    /**
+     * Catalog content tags for every product currently in the cart.
+     *
+     * Tagging the cached cart with "product_{id}" lets the existing Product
+     * listener purge invalidate this cart whenever one of its products
+     * changes — no extra listener code needed.
+     */
+    protected static function productTags(): array
+    {
+        try {
+            $cart = Cart::getCart();
+
+            if (! $cart) {
+                return [];
+            }
+
+            $ids = [];
+
+            foreach ($cart->items as $item) {
+                $ids[] = $item->product_id;
+
+                foreach ($item->children as $child) {
+                    $ids[] = $child->product_id;
+                }
+            }
+
+            return CartCacheContext::productTags($ids);
+        } catch (\Throwable) {
+            return [];
+        }
     }
 
     /**

--- a/packages/Webkul/LSC/src/Support/PrivateCompareCache.php
+++ b/packages/Webkul/LSC/src/Support/PrivateCompareCache.php
@@ -3,6 +3,7 @@
 namespace Webkul\LSC\Support;
 
 use Illuminate\Http\Request;
+use Webkul\Customer\Repositories\CompareItemRepository;
 
 class PrivateCompareCache
 {
@@ -12,7 +13,10 @@ class PrivateCompareCache
     public static function apply(mixed $response, Request $request, string $scope): mixed
     {
         $ttl = max(60, (int) config('lscache.private_ttl', 300));
-        $tags = CartCacheContext::responseTagsForFamily('compare-private', $scope, $request);
+        $tags = array_merge(
+            CartCacheContext::responseTagsForFamily('compare-private', $scope, $request),
+            self::productTags($request)
+        );
         $cacheControl = 'private,max-age='.$ttl;
         $privateCookieName = CartCacheContext::privateCookieName();
         $privateCookieValue = CartCacheContext::privateCookieValue($request);
@@ -36,6 +40,32 @@ class PrivateCompareCache
         ));
 
         return LiteSpeedDebug::attachToResponse($response, $tags, $cacheControl);
+    }
+
+    /**
+     * Catalog content tags for every product in the compare list.
+     *
+     * Customers store compare items in the database; guests pass them as the
+     * "product_ids" request input. Tagging the cached compare list with
+     * "product_{id}" lets the existing Product listener purge invalidate it
+     * whenever one of its products changes — no extra listener code needed.
+     */
+    protected static function productTags(Request $request): array
+    {
+        try {
+            if ($customerId = auth()->guard('customer')->id()) {
+                $ids = app(CompareItemRepository::class)
+                    ->findByField('customer_id', $customerId)
+                    ->pluck('product_id')
+                    ->all();
+            } else {
+                $ids = (array) $request->input('product_ids', []);
+            }
+
+            return CartCacheContext::productTags($ids);
+        } catch (\Throwable) {
+            return [];
+        }
     }
 
     /**

--- a/packages/Webkul/LSC/src/Support/PrivateCompareCache.php
+++ b/packages/Webkul/LSC/src/Support/PrivateCompareCache.php
@@ -17,7 +17,7 @@ class PrivateCompareCache
             CartCacheContext::responseTagsForFamily('compare-private', $scope, $request),
             self::productTags($request)
         );
-        $cacheControl = 'private,max-age='.$ttl;
+        $cacheControl = CartCacheContext::withEsi('private,max-age='.$ttl);
         $privateCookieName = CartCacheContext::privateCookieName();
         $privateCookieValue = CartCacheContext::privateCookieValue($request);
 

--- a/packages/Webkul/LSC/src/Support/PrivateEsiCache.php
+++ b/packages/Webkul/LSC/src/Support/PrivateEsiCache.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Webkul\LSC\Support;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Cookie;
+
+class PrivateEsiCache
+{
+    /**
+     * Apply private LiteSpeed cache headers to an ESI fragment response.
+     *
+     * Mirrors PrivateCartCache::apply but for per-user header fragments
+     * (login dropdowns, mini-cart count) served as ESI includes. Each fragment:
+     *
+     *  - is cached privately, keyed per customer/guest via the `lsc_private`
+     *    cookie (X-LiteSpeed-Vary), with its own short TTL;
+     *  - carries a context-scoped purge tag ("{scope}-{context}") so it can be
+     *    invalidated on the relevant change (login/logout, cart mutation);
+     *  - sets the `lsc_private` cookie so the next request keys correctly even
+     *    when the cookie was not present on the parent (public) page — the
+     *    parent page must never set a per-user cookie, since it is shared.
+     *
+     *  LiteSpeed discards private ESI blocks larger than 8 KB, so keep the
+     *  rendered fragments lean.
+     */
+    public static function apply(mixed $response, Request $request, string $scope, array $extraTags = []): mixed
+    {
+        $ttl = CartCacheContext::privateTtl();
+
+        $tags = array_values(array_unique(array_merge(
+            CartCacheContext::responseTags($scope, $request),
+            $extraTags
+        )));
+
+        $cacheControl = 'private,max-age='.$ttl;
+
+        $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate, private');
+        $response->headers->set('Pragma', 'no-cache');
+        $response->headers->set('Expires', '0');
+        $response->headers->set('X-LiteSpeed-Cache-Control', $cacheControl);
+        $response->headers->set('X-LiteSpeed-Tag', implode(',', $tags));
+        $response->headers->set('X-LiteSpeed-Vary', CartCacheContext::varyHeader($request));
+        $response->headers->setCookie(new Cookie(
+            CartCacheContext::privateCookieName(),
+            CartCacheContext::privateCookieValue($request),
+            0,
+            '/',
+            config('session.domain'),
+            (bool) config('session.secure'),
+            false,
+            false,
+            config('session.same_site', 'lax')
+        ));
+
+        return LiteSpeedDebug::attachToResponse($response, $tags, $cacheControl);
+    }
+}

--- a/packages/Webkul/LSC/src/Support/PrivateWishlistCache.php
+++ b/packages/Webkul/LSC/src/Support/PrivateWishlistCache.php
@@ -3,6 +3,7 @@
 namespace Webkul\LSC\Support;
 
 use Illuminate\Http\Request;
+use Webkul\Customer\Repositories\WishlistRepository;
 
 class PrivateWishlistCache
 {
@@ -12,7 +13,10 @@ class PrivateWishlistCache
     public static function apply(mixed $response, Request $request, string $scope): mixed
     {
         $ttl = max(60, (int) config('lscache.private_ttl', 300));
-        $tags = CartCacheContext::responseTagsForFamily('wishlist-private', $scope, $request);
+        $tags = array_merge(
+            CartCacheContext::responseTagsForFamily('wishlist-private', $scope, $request),
+            self::productTags()
+        );
         $cacheControl = 'private,max-age='.$ttl;
         $privateCookieName = CartCacheContext::privateCookieName();
         $privateCookieValue = CartCacheContext::privateCookieValue($request);
@@ -36,6 +40,34 @@ class PrivateWishlistCache
         ));
 
         return LiteSpeedDebug::attachToResponse($response, $tags, $cacheControl);
+    }
+
+    /**
+     * Catalog content tags for every product on the customer's wishlist.
+     *
+     * Tagging the cached wishlist with "product_{id}" lets the existing
+     * Product listener purge invalidate it whenever one of its products
+     * changes — no extra listener code needed.
+     */
+    protected static function productTags(): array
+    {
+        try {
+            $customerId = auth()->guard('customer')->id();
+
+            if (! $customerId) {
+                return [];
+            }
+
+            $ids = app(WishlistRepository::class)
+                ->where(['customer_id' => $customerId])
+                ->get()
+                ->pluck('product_id')
+                ->all();
+
+            return CartCacheContext::productTags($ids);
+        } catch (\Throwable) {
+            return [];
+        }
     }
 
     /**

--- a/packages/Webkul/LSC/src/Support/PrivateWishlistCache.php
+++ b/packages/Webkul/LSC/src/Support/PrivateWishlistCache.php
@@ -17,7 +17,7 @@ class PrivateWishlistCache
             CartCacheContext::responseTagsForFamily('wishlist-private', $scope, $request),
             self::productTags()
         );
-        $cacheControl = 'private,max-age='.$ttl;
+        $cacheControl = CartCacheContext::withEsi('private,max-age='.$ttl);
         $privateCookieName = CartCacheContext::privateCookieName();
         $privateCookieValue = CartCacheContext::privateCookieValue($request);
 


### PR DESCRIPTION
## Summary

  Two related improvements to the LiteSpeed Cache (LSC) plugin:

  1. **One cache tag per route** for the private caches. Cart/wishlist/compare
     responses previously emitted 3-4 tags (`cart-private`, `cart-private-{ctx}`,
     `cart-api`, `cart-api-{ctx}`, ...). They now emit a single
     `{scope}-{ctx}` tag per route, e.g. `cart-api-{ctx}`. Purges collapse the
     same way. No middleware or listener call sites needed changing.

  2. **Customer-group cache vary** for public pages. Product/category/listing
     pages were cached as one shared copy, so a guest could be served the
     wholesale price (and vice versa). The public cache now varies by customer
     group, locale and currency, giving each group its own cached variant.

  ## Changes (plugin — `packages/Webkul/LSC`)

  - `Support/CartCacheContext.php` — collapse private tags to one-per-route;
    add `lsc_customer_group` cookie constant and `groupCookieName()`,
    `currentGroupCode()`, `publicVaryHeader()` helpers.
  - `Http/Middleware/CustomerGroupCookie.php` — **new**; keeps the unencrypted
    `lsc_customer_group` cookie in sync with the visitor's group.
  - `Http/Middleware/LSCacheHeaders.php` — emit `X-LiteSpeed-Vary` on public
    cached responses; tag non-category product listings with `product-listing`
    so they are cacheable.
  - `Providers/LSCServiceProvider.php` — register `CustomerGroupCookie` on the
    `web` group; add `lsc_customer_group` to the cookie-encryption exceptions.
  - `Listeners/Product.php` — purge the `product-listing` tag on product
    create / update / delete.

  ## Required change OUTSIDE this repo (main application)

  The customer-group vary only takes effect once LiteSpeed is told which
  cookies to key the public cache on. This is **not** part of the plugin —
  it must be added to the application's `public/.htaccess`, inside the
  existing `<IfModule LiteSpeed>` block:

      RewriteEngine On
      RewriteRule .* - [E="Cache-Vary:lsc_customer_group,bagisto_locale,bagisto_currency"]

  Without this directive LiteSpeed keeps a single shared public copy and the
  price will be wrong for some groups.

  ## Deploy notes

  - Apply the `.htaccess` change to the main app repo.
  - Purge the existing LiteSpeed cache once after deploy (old multi-tag and
    un-varied entries become stale).
  - Restart LiteSpeed / lsphp so opcache picks up the new middleware.

  ## Test plan

  - [ ] `/api/checkout/cart` emits exactly one tag (`cart-api-{ctx}`); a cart
        mutation purges the three cart-scope tags only.
  - [ ] Wishlist and compare collapse to one tag per route the same way.
  - [ ] `/api/products?featured=1` is cacheable and emits `X-LiteSpeed-Vary`.
  - [ ] Same product page served to a guest vs a wholesale customer produces
        separate cache entries (first request of each variant is a MISS).
  - [ ] Guest sees the guest price, wholesale customer sees the wholesale
        price — no cross-group price leakage.
  - [ ] Editing a product purges all group variants.